### PR TITLE
Add missing packages on lambda functions

### DIFF
--- a/waf-operations.yaml
+++ b/waf-operations.yaml
@@ -335,7 +335,8 @@ Resources:
                 - $VIRTUAL_ENV/bin/pip3 install -U user_agents
                 - $VIRTUAL_ENV/bin/pip3 install -U counter_robots
                 - $VIRTUAL_ENV/bin/pip3 install -U packaging
-                - $VIRTUAL_ENV/bin/pip3 install -U jaraco.classes jaraco.collections jaraco.context jaraco.functools jaraco.logging jaraco.path jaraco.text jaraco.ui jaraco.collections jaraco.itertools jaraco.stream jaraco.envs jaraco.services jaraco.logging jaraco.util jaraco.context jaraco.windows jaraco.mongodb jaraco.finance jaraco.packaging jaraco.network jaraco.structures jaraco.xml
+                - $VIRTUAL_ENV/bin/pip3 install -U jaraco.text
+                - $VIRTUAL_ENV/bin/pip3 install -U platformdirs
                 - $VIRTUAL_ENV/lib/python3.9/site-packages/bin/pyasn_util_download.py --latest
                 - RIB_FILE=`ls rib.*`
                 - $VIRTUAL_ENV/lib/python3.9/site-packages/bin/pyasn_util_convert.py --single $RIB_FILE ipasn.dat

--- a/waf-operations.yaml
+++ b/waf-operations.yaml
@@ -334,6 +334,8 @@ Resources:
                 - $VIRTUAL_ENV/bin/pip3 install -U --target $VIRTUAL_ENV/lib/python3.9/site-packages pyasn
                 - $VIRTUAL_ENV/bin/pip3 install -U user_agents
                 - $VIRTUAL_ENV/bin/pip3 install -U counter_robots
+                - $VIRTUAL_ENV/bin/pip3 install -U packaging
+                - $VIRTUAL_ENV/bin/pip3 install -U jaraco.classes jaraco.collections jaraco.context jaraco.functools jaraco.logging jaraco.path jaraco.text jaraco.ui jaraco.collections jaraco.itertools jaraco.stream jaraco.envs jaraco.services jaraco.logging jaraco.util jaraco.context jaraco.windows jaraco.mongodb jaraco.finance jaraco.packaging jaraco.network jaraco.structures jaraco.xml
                 - $VIRTUAL_ENV/lib/python3.9/site-packages/bin/pyasn_util_download.py --latest
                 - RIB_FILE=`ls rib.*`
                 - $VIRTUAL_ENV/lib/python3.9/site-packages/bin/pyasn_util_convert.py --single $RIB_FILE ipasn.dat


### PR DESCRIPTION
*Issue #12, if available:*

*Description of changes:*

Added the python packages `packaging` and `jaraco.*` to the CodeBuild module in `waf-operations.yaml`.

It appears to solve the issue with the `log-enrichment` function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
